### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -3,6 +3,9 @@
 
 name: Go
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/ZeTr0nIx/gin-memory-sessions-go/security/code-scanning/1](https://github.com/ZeTr0nIx/gin-memory-sessions-go/security/code-scanning/1)

To fix the problem, explicitly define the `permissions` for the workflow or specifically for the `build` job so that the automatically generated `GITHUB_TOKEN` has only the minimal access required. For this workflow—which only checks out code and runs Go build/tests—`contents: read` is sufficient.

The best minimal fix without changing existing functionality is to add a `permissions` block at the workflow root level (so it applies to all jobs) specifying `contents: read`. Concretely, in `.github/workflows/go.yml`, insert:

```yml
permissions:
  contents: read
```

between the `name: Go` (line 4) and the `on:` block (line 6). No other changes, imports, or additional definitions are required, since this is pure workflow configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
